### PR TITLE
Update to Android M

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+language: android
+
+jdk:
+  - oraclejdk8
+  - oraclejdk7
+
+android:
+  components:
+    - platform-tools
+    - tools
+    - build-tools-23.0.2
+    - android-22
+    - android-23
+    - extra-google-m2repository
+    - extra-android-m2repository
+    - extra-android-support
+    - sys-img-armeabi-v7a-android-10
+    - sys-img-armeabi-v7a-android-15
+    - sys-img-armeabi-v7a-android-16
+    - sys-img-armeabi-v7a-android-17
+    - sys-img-armeabi-v7a-android-18
+    - sys-img-armeabi-v7a-android-19
+    - sys-img-armeabi-v7a-android-21
+    - sys-img-armeabi-v7a-android-22
+
+env:
+  matrix:
+    - ANDROID_EMULATOR=android-10 ANDROID_ABI=armeabi
+    - ANDROID_EMULATOR=android-15 ANDROID_ABI=armeabi-v7a
+    - ANDROID_EMULATOR=android-16 ANDROID_ABI=armeabi-v7a
+    - ANDROID_EMULATOR=android-17 ANDROID_ABI=armeabi-v7a
+    - ANDROID_EMULATOR=android-18 ANDROID_ABI=armeabi-v7a
+    - ANDROID_EMULATOR=android-19 ANDROID_ABI=armeabi-v7a
+    - ANDROID_EMULATOR=android-21 ANDROID_ABI=armeabi-v7a
+    - ANDROID_EMULATOR=android-22 ANDROID_ABI=armeabi-v7a
+
+before_script:
+  - echo no | android create avd --force -n test -t $ANDROID_EMULATOR --abi $ANDROID_ABI
+  - emulator -avd test -no-skin -no-audio -no-window &
+  - android-wait-for-emulator
+  - adb shell input keyevent 82 &

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,11 +43,11 @@ configurations.all {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    androidTestCompile 'junit:junit:4.12'
     androidTestCompile 'com.android.support.test:runner:0.4'
     androidTestCompile 'com.android.support.test:rules:0.4'
     androidTestCompile 'com.squareup.okhttp:mockwebserver:2.4.0'
 
+    compile 'junit:junit:4.12'
     compile 'com.feedhenry:fh-android-sdk:3.0.0'
     compile 'com.android.support:appcompat-v7:23.1.1'
     compile 'com.android.support:design:23.1.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,18 +5,23 @@ plugins {
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion "22.0.1"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.2"
 
     defaultConfig {
         applicationId "com.feedhenry.oauth.oauth_android_app"
         minSdkVersion 10
-        targetSdkVersion 22
+        targetSdkVersion 23
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         testApplicationId "com.feedhenry.oauth.oauth_android_app.test"
     }
+
+    lintOptions {
+        abortOnError false
+    }
+
     buildTypes {
         release {
             minifyEnabled false
@@ -30,19 +35,21 @@ license {
     strictCheck true
 }
 
+configurations.all {
+    resolutionStrategy {
+        force 'com.android.support:support-annotations:23.1.1'
+    }
+}
+
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     androidTestCompile 'junit:junit:4.12'
-    androidTestCompile 'com.android.support.test:runner:0.3'
-    androidTestCompile 'com.android.support.test:rules:0.3'
+    androidTestCompile 'com.android.support.test:runner:0.4'
+    androidTestCompile 'com.android.support.test:rules:0.4'
     androidTestCompile 'com.squareup.okhttp:mockwebserver:2.4.0'
 
-
-
-
-    compile 'com.android.support:appcompat-v7:22.2.0'
-
-    compile 'com.feedhenry:fh-android-sdk:2.5.0'
+    compile 'com.feedhenry:fh-android-sdk:3.0.0'
+    compile 'com.android.support:appcompat-v7:23.1.1'
+    compile 'com.android.support:design:23.1.1'
     compile 'com.jakewharton:butterknife:7.0.1'
-    compile 'com.android.support:design:22.2.0'
 }

--- a/app/src/androidTest/java/com/feedhenry/helloworld/test/OAuthWelcomeTest.java
+++ b/app/src/androidTest/java/com/feedhenry/helloworld/test/OAuthWelcomeTest.java
@@ -112,7 +112,7 @@ public class OAuthWelcomeTest extends ActivityUnitTestCase<OAuthWelcome> {
         }
 
         RecordedRequest request = mockWebServer.takeRequest(5, TimeUnit.SECONDS);
-        assertEquals("/box/srv/1.1/verifysession", request.getPath());
+        assertEquals("/box/srv/1.1/admin/authpolicy/verifysession", request.getPath());
         assertEquals("{\"sessionToken\":\"testToken\"}", request.getBody().readString(Charset.forName("UTF-8")));
 
 

--- a/app/src/androidTest/java/com/feedhenry/helloworld/test/activity/StubFHOAuthActivity.java
+++ b/app/src/androidTest/java/com/feedhenry/helloworld/test/activity/StubFHOAuthActivity.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.feedhenry.helloworld.test.activity;
 
 import android.os.Bundle;

--- a/app/src/main/res/layout/activity_stub_fhoauth.xml
+++ b/app/src/main/res/layout/activity_stub_fhoauth.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+
+    Copyright 2015 Red Hat, Inc., and individual contributors
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"

--- a/app/src/main/res/layout/content_stub_fhoauth.xml
+++ b/app/src/main/res/layout/content_stub_fhoauth.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+
+    Copyright 2015 Red Hat, Inc., and individual contributors
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"

--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -1,3 +1,20 @@
+<!--
+
+    Copyright 2015 Red Hat, Inc., and individual contributors
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <resources>>
 
     <style name="AppTheme.NoActionBar">

--- a/build.gradle
+++ b/build.gradle
@@ -5,10 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.0'
-
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
+        classpath 'com.android.tools.build:gradle:1.3.1'
     }
 }
 


### PR DESCRIPTION
* [RHMAP-3454](https://issues.jboss.org/browse/RHMAP-3454) - Update templates to use FH Android SDK 3.0.0
* [RHMAP-3183](https://issues.jboss.org/browse/RHMAP-3183) - Update templates minSdkVersion to 10
* [RHMAP-3184](https://issues.jboss.org/browse/RHMAP-3184) - Update templates targetVersion to 23
* [RHMAP-2851](https://issues.jboss.org/browse/RHMAP-2851) - Add Travis-ci in Android Templates
* [RHMAP-3036](https://issues.jboss.org/browse/RHMAP-3036) - Add travis-ci build matrix to all supported Android/Java versions in 
