### PR TITLE
Android N with Jack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,40 +5,59 @@ dist: precise
 
 jdk:
   - oraclejdk8
-  - oraclejdk7
 
 android:
   components:
     - platform-tools
     - tools
-    - build-tools-23.0.2
+    - build-tools-24.0.3
     - android-22
     - android-23
+    - android-24
     - extra-google-m2repository
     - extra-android-m2repository
     - extra-android-support
-    - sys-img-armeabi-v7a-android-10
-    - sys-img-armeabi-v7a-android-15
-    - sys-img-armeabi-v7a-android-16
-    - sys-img-armeabi-v7a-android-17
-    - sys-img-armeabi-v7a-android-18
-    - sys-img-armeabi-v7a-android-19
-    - sys-img-armeabi-v7a-android-21
-    - sys-img-armeabi-v7a-android-22
+licenses:
+    - android-sdk-license-5be876d5
 
 env:
+  global:
+    - ADB_INSTALL_TIMEOUT=10
   matrix:
-    - ANDROID_EMULATOR=android-10 ANDROID_ABI=armeabi
-    - ANDROID_EMULATOR=android-15 ANDROID_ABI=armeabi-v7a
-    - ANDROID_EMULATOR=android-16 ANDROID_ABI=armeabi-v7a
-    - ANDROID_EMULATOR=android-17 ANDROID_ABI=armeabi-v7a
-    - ANDROID_EMULATOR=android-18 ANDROID_ABI=armeabi-v7a
-    - ANDROID_EMULATOR=android-19 ANDROID_ABI=armeabi-v7a
-    - ANDROID_EMULATOR=android-21 ANDROID_ABI=armeabi-v7a
-    - ANDROID_EMULATOR=android-22 ANDROID_ABI=armeabi-v7a
+    - ANDROID_EMULATOR=android-10 ANDROID_ABI=armeabi     ANDROID_PKGS=sys-img-armeabi-v7a-android-10
+    - ANDROID_EMULATOR=android-15 ANDROID_ABI=armeabi-v7a ANDROID_PKGS=sys-img-armeabi-v7a-android-15
+    - ANDROID_EMULATOR=android-16 ANDROID_ABI=armeabi-v7a ANDROID_PKGS=sys-img-armeabi-v7a-android-16
+    - ANDROID_EMULATOR=android-17 ANDROID_ABI=armeabi-v7a ANDROID_PKGS=sys-img-armeabi-v7a-android-17
+    - ANDROID_EMULATOR=android-18 ANDROID_ABI=armeabi-v7a ANDROID_PKGS=sys-img-armeabi-v7a-android-18
+    - ANDROID_EMULATOR=android-19 ANDROID_ABI=armeabi-v7a ANDROID_PKGS=sys-img-armeabi-v7a-android-19
+    - ANDROID_EMULATOR=android-21 ANDROID_ABI=armeabi-v7a ANDROID_PKGS=sys-img-armeabi-v7a-android-21
+    - ANDROID_EMULATOR=android-22 ANDROID_ABI=armeabi-v7a ANDROID_PKGS=sys-img-armeabi-v7a-android-22
+    - ANDROID_EMULATOR=android-23 ANDROID_ABI=armeabi-v7a ANDROID_PKGS=sys-img-armeabi-v7a-android-23
+    - ANDROID_EMULATOR=android-24 ANDROID_ABI=armeabi-v7a ANDROID_PKGS=sys-img-armeabi-v7a-android-24
+
+before_cache:
+  - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+
+before_install:
+  - echo y | android update sdk -a -u -t ${ANDROID_PKGS:-}
+
+install:
+  - echo no | android create avd --force -n test -t "$ANDROID_EMULATOR" --abi "$ANDROID_ABI"
+  - emulator -avd test -no-skin -no-audio -no-window &
+  - adb wait-for-device get-serialno
+  - ./gradlew --version
+  - ./gradlew clean
 
 before_script:
-  - echo no | android create avd --force -n test -t $ANDROID_EMULATOR --abi $ANDROID_ABI
-  - emulator -avd test -no-skin -no-audio -no-window &
   - android-wait-for-emulator
   - adb shell input keyevent 82 &
+
+script:
+  - ./gradlew build connectedCheck
+
+after_script:
+  - cat logcat.log; pkill -KILL -f adb

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,6 +16,15 @@ android {
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         testApplicationId "com.feedhenry.oauth.oauth_android_app.test"
+
+        jackOptions {
+            enabled true
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     lintOptions {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -60,6 +60,8 @@ dependencies {
     androidTestCompile 'com.android.support.test:runner:0.5'
     androidTestCompile 'com.android.support.test:rules:0.5'
     androidTestCompile 'com.squareup.okhttp:mockwebserver:2.4.0'
+    androidTestCompile 'junit:junit:4.12'
+    androidTestCompile 'org.mockito:mockito-core:1.10.19'
 
     compile 'junit:junit:4.12'
     compile 'com.feedhenry:fh-android-sdk:3.2.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     androidTestCompile 'com.squareup.okhttp:mockwebserver:2.4.0'
 
     compile 'junit:junit:4.12'
-    compile 'com.feedhenry:fh-android-sdk:3.1.0'
+    compile 'com.feedhenry:fh-android-sdk:3.2.0'
     compile 'com.android.support:appcompat-v7:23.1.1'
     compile 'com.android.support:design:23.1.1'
     compile 'com.jakewharton:butterknife:7.0.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,13 +5,13 @@ plugins {
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    compileSdkVersion 24
+    buildToolsVersion "24.0.3"
 
     defaultConfig {
         applicationId "com.feedhenry.oauth.oauth_android_app"
         minSdkVersion 10
-        targetSdkVersion 23
+        targetSdkVersion 24
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -42,19 +42,19 @@ license {
 
 configurations.all {
     resolutionStrategy {
-        force 'com.android.support:support-annotations:23.1.1'
+        force 'com.android.support:support-annotations:24.2.1'
     }
 }
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    androidTestCompile 'com.android.support.test:runner:0.4'
-    androidTestCompile 'com.android.support.test:rules:0.4'
+    androidTestCompile 'com.android.support.test:runner:0.5'
+    androidTestCompile 'com.android.support.test:rules:0.5'
     androidTestCompile 'com.squareup.okhttp:mockwebserver:2.4.0'
 
     compile 'junit:junit:4.12'
     compile 'com.feedhenry:fh-android-sdk:3.2.0'
-    compile 'com.android.support:appcompat-v7:23.1.1'
-    compile 'com.android.support:design:23.1.1'
+    compile 'com.android.support:appcompat-v7:24.2.1'
+    compile 'com.android.support:design:24.2.1'
     compile 'com.jakewharton:butterknife:7.0.1'
 }

--- a/app/src/androidTest/java/com/feedhenry/helloworld/test/OAuthWelcomeTest.java
+++ b/app/src/androidTest/java/com/feedhenry/helloworld/test/OAuthWelcomeTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2015 Red Hat, Inc., and individual contributors
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,21 +15,13 @@
  */
 package com.feedhenry.helloworld.test;
 
-
 import android.content.ContextWrapper;
 import android.content.Intent;
-import android.content.res.AssetManager;
-import android.os.Bundle;
-import android.support.test.InstrumentationRegistry;
 import android.support.test.filters.LargeTest;
-import android.support.test.internal.runner.junit4.AndroidJUnit4ClassRunner;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
-import android.test.ActivityUnitTestCase;
-import android.view.ContextThemeWrapper;
 import android.view.View;
 
-import com.feedhenry.helloworld.test.activity.StubFHOAuthActivity;
 import com.feedhenry.oauth.oauth_android_app.OAuthWelcome;
 import com.feedhenry.oauth.oauth_android_app.R;
 import com.feedhenry.sdk.FH;
@@ -54,11 +46,9 @@ import java.util.concurrent.TimeUnit;
 
 import static android.support.test.InstrumentationRegistry.getInstrumentation;
 
-
 @RunWith(AndroidJUnit4.class)
 @LargeTest
 public class OAuthWelcomeTest {
-
 
     private MockWebServer mockWebServer = null;
     private long startTime;
@@ -67,7 +57,6 @@ public class OAuthWelcomeTest {
     @Rule
     public ActivityTestRule<OAuthWelcome> mActivityRule = new ActivityTestRule<>(
             OAuthWelcome.class, false, false);
-
 
     @Before
     public void setUp() throws Exception {
@@ -126,7 +115,6 @@ public class OAuthWelcomeTest {
         main.finish();
     }
 
-
     @Test
     public void testLogoutButtonShowsIfLoggedIn() throws IOException, InterruptedException {
 
@@ -141,7 +129,6 @@ public class OAuthWelcomeTest {
 //                    main.onStart();
 //                });
 //
-
         while (main.findViewById(R.id.log_out).getVisibility() == View.GONE) {
             Assert.assertTrue("Timeout after 5 seconds", System.currentTimeMillis() - startTime < 5000);
         }
@@ -152,6 +139,5 @@ public class OAuthWelcomeTest {
 
         main.finish();
     }
-
 
 }

--- a/app/src/androidTest/java/com/feedhenry/helloworld/test/OAuthWelcomeTest.java
+++ b/app/src/androidTest/java/com/feedhenry/helloworld/test/OAuthWelcomeTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2015 Red Hat, Inc., and individual contributors
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,48 +16,90 @@
 package com.feedhenry.helloworld.test;
 
 
+import android.content.ContextWrapper;
 import android.content.Intent;
+import android.content.res.AssetManager;
 import android.os.Bundle;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.filters.LargeTest;
+import android.support.test.internal.runner.junit4.AndroidJUnit4ClassRunner;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
 import android.test.ActivityUnitTestCase;
 import android.view.ContextThemeWrapper;
 import android.view.View;
 
+import com.feedhenry.helloworld.test.activity.StubFHOAuthActivity;
 import com.feedhenry.oauth.oauth_android_app.OAuthWelcome;
 import com.feedhenry.oauth.oauth_android_app.R;
+import com.feedhenry.sdk.FH;
+import com.feedhenry.sdk.FHActCallback;
+import com.feedhenry.sdk.FHResponse;
 import com.feedhenry.sdk.utils.DataManager;
 import com.squareup.okhttp.mockwebserver.MockResponse;
 import com.squareup.okhttp.mockwebserver.MockWebServer;
 import com.squareup.okhttp.mockwebserver.RecordedRequest;
 
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-public class OAuthWelcomeTest extends ActivityUnitTestCase<OAuthWelcome> {
+import static android.support.test.InstrumentationRegistry.getInstrumentation;
 
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class OAuthWelcomeTest {
 
 
     private MockWebServer mockWebServer = null;
     private long startTime;
-    public OAuthWelcomeTest() {
-        super(OAuthWelcome.class);
-    }
+    private ContextWrapper context;
 
+    @Rule
+    public ActivityTestRule<OAuthWelcome> mActivityRule = new ActivityTestRule<>(
+            OAuthWelcome.class, false, false);
+
+
+    @Before
     public void setUp() throws Exception {
-        super.setUp();
         mockWebServer = new MockWebServer();
         mockWebServer.start(9000);
-        ContextThemeWrapper context = new AlternateAssetsContextWrapper(getInstrumentation().getTargetContext(), R.style.AppTheme, getInstrumentation().getContext());
-        setActivityContext(context);
+
+        context = new AlternateAssetsContextWrapper(getInstrumentation().getTargetContext(), R.style.AppTheme, getInstrumentation().getContext());
+
+        CountDownLatch latch = new CountDownLatch(1);
+
+        FH.init(context, new FHActCallback() {
+            @Override
+            public void success(FHResponse pResponse) {
+                latch.countDown();
+            }
+
+            @Override
+            public void fail(FHResponse pResponse) {
+                latch.countDown();
+            }
+        });
+        latch.await(5, TimeUnit.SECONDS);
+
+
         startTime = System.currentTimeMillis();
         DataManager.init(context);
         DataManager.getInstance().remove("sessionToken");
     }
 
-    @Override
-    protected void tearDown() throws Exception {
-        super.tearDown();
-        try{
+    @After
+    public void tearDown() throws Exception {
+        try {
             mockWebServer.shutdown();
         } catch (Exception ignore) {
 
@@ -65,56 +107,48 @@ public class OAuthWelcomeTest extends ActivityUnitTestCase<OAuthWelcome> {
         Thread.sleep(5000);
     }
 
+    @Test
     public void testLoginButtonShowsIfNotLoggedIn() throws IOException {
 
-        getInstrumentation().runOnMainSync(new Runnable() {
-            @Override
-            public void run() {
-                OAuthWelcome activity = startActivity(new Intent(), Bundle.EMPTY, null);
+        OAuthWelcome main = mActivityRule.launchActivity(new Intent(context, OAuthWelcome.class));
+//
+//        getInstrumentation().runOnMainSync(
+//            () -> {
+//                main.onCreate(new Bundle());
+//                main.onStart();
+//            });
 
-                activity.onStart();
-            }
-        });
-
-
-        OAuthWelcome main = getActivity();
 
         while (main.findViewById(R.id.log_in).getVisibility() == View.GONE) {
-            assertTrue("Timeout after 5 seconds", System.currentTimeMillis() - startTime < 5000);
+            Assert.assertTrue("Timeout after 5 seconds", System.currentTimeMillis() - startTime < 5000);
         }
 
         main.finish();
     }
 
 
-
-
+    @Test
     public void testLogoutButtonShowsIfLoggedIn() throws IOException, InterruptedException {
 
         DataManager.getInstance().save("sessionToken", "testToken");
         //Code will call verify which should call the server
         mockWebServer.enqueue(new MockResponse().setResponseCode(200).setBody("{\"isValid\":\"true\"}"));
 
-        getInstrumentation().runOnMainSync(new Runnable() {
-            @Override
-            public void run() {
-                OAuthWelcome activity = startActivity(new Intent(), Bundle.EMPTY, null);
-
-                activity.onStart();
-            }
-        });
-
-
-        OAuthWelcome main = getActivity();
+        OAuthWelcome main = mActivityRule.launchActivity(new Intent(context, OAuthWelcome.class));
+//
+//        getInstrumentation().runOnMainSync(
+//                () -> {
+//                    main.onStart();
+//                });
+//
 
         while (main.findViewById(R.id.log_out).getVisibility() == View.GONE) {
-            assertTrue("Timeout after 5 seconds", System.currentTimeMillis() - startTime < 5000);
+            Assert.assertTrue("Timeout after 5 seconds", System.currentTimeMillis() - startTime < 5000);
         }
 
         RecordedRequest request = mockWebServer.takeRequest(5, TimeUnit.SECONDS);
-        assertEquals("/box/srv/1.1/admin/authpolicy/verifysession", request.getPath());
-        assertEquals("{\"sessionToken\":\"testToken\"}", request.getBody().readString(Charset.forName("UTF-8")));
-
+        Assert.assertEquals("/box/srv/1.1/admin/authpolicy/verifysession", request.getPath());
+        Assert.assertEquals("{\"sessionToken\":\"testToken\"}", request.getBody().readString(Charset.forName("UTF-8")));
 
         main.finish();
     }

--- a/app/src/assets/fhconfig.properties
+++ b/app/src/assets/fhconfig.properties
@@ -1,5 +1,0 @@
-host =
-appid =
-projectid =
-appkey =
-connectiontag =

--- a/app/src/main/java/com/feedhenry/oauth/oauth_android_app/OAuthWelcome.java
+++ b/app/src/main/java/com/feedhenry/oauth/oauth_android_app/OAuthWelcome.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2015 Red Hat, Inc., and individual contributors
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,21 +32,25 @@ import butterknife.OnClick;
  */
 public class OAuthWelcome extends FHOAuth {
 
-    @Bind(R.id.repsonse) TextView response;
-    @Bind(R.id.progress_bar) View progressBar;
-    @Bind(R.id.log_in) View logInButton;
-    @Bind(R.id.log_out) View logOutButton;
+    @Bind(R.id.repsonse)
+    TextView response;
+    @Bind(R.id.progress_bar)
+    View progressBar;
+    @Bind(R.id.log_in)
+    View logInButton;
+    @Bind(R.id.log_out)
+    View logOutButton;
 
 
     private static final String TAG = "FHAuthActivity";
 
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
+    public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_oauth_welcome);
         ButterKnife.bind(this);
-    }
 
+    }
 
     @OnClick(R.id.log_in)
     public void login() {
@@ -78,6 +82,14 @@ public class OAuthWelcome extends FHOAuth {
 
     @Override
     public void onNotLoggedIn() {
+
+        if (response == null) { //Testing context doesn't work with butterknife correctly
+            response = (TextView) findViewById(R.id.repsonse);
+            progressBar = findViewById(R.id.progress_bar);
+            logInButton = findViewById(R.id.log_in);
+            logOutButton = findViewById(R.id.log_out);
+        }
+
         response.setText(getString(R.string.not_logged_in_message));
         progressBar.setVisibility(View.GONE);
         logInButton.setVisibility(View.VISIBLE);
@@ -86,7 +98,18 @@ public class OAuthWelcome extends FHOAuth {
 
     @Override
     public void onSessionValid(String sessionToken) {
-        response.setText(String.format(getString(R.string.logged_in_message), sessionToken));
+        if (response == null) { //Testing context doesn't work with butterknife correctly
+            response = (TextView) findViewById(R.id.repsonse);
+            progressBar = findViewById(R.id.progress_bar);
+            logInButton = findViewById(R.id.log_in);
+            logOutButton = findViewById(R.id.log_out);
+        }
+
+        response.setText(String.format(
+
+                getString(R.string.logged_in_message), sessionToken
+
+        ));
         progressBar.setVisibility(View.GONE);
         logInButton.setVisibility(View.GONE);
         logOutButton.setVisibility(View.VISIBLE);

--- a/app/src/main/java/com/feedhenry/oauth/oauth_android_app/OAuthWelcome.java
+++ b/app/src/main/java/com/feedhenry/oauth/oauth_android_app/OAuthWelcome.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2015 Red Hat, Inc., and individual contributors
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.android.tools.build:gradle:2.2.1'
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
-# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit


### PR DESCRIPTION
Related Jiras:

* [FH-2817](https://issues.jboss.org/browse/FH-2817) - Update fh-android-sdk dependency in all Android template for 3.2.0
* [FH-2705](https://issues.jboss.org/browse/FH-2705) - Update Android Plugin for Gradle on templates
* [FH-2735](https://issues.jboss.org/browse/FH-2735) - Update templates to target Android N 
* [FH-2737](https://issues.jboss.org/browse/FH-2737) - Update templates to use Jack
